### PR TITLE
Run tests for testOnSave setting

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,6 +5,7 @@ import { TestResult } from "./testResult";
 export class Commands {
 
     private readonly onTestDiscoveryFinishedEmitter = new EventEmitter<TestNode[]>();
+    private readonly onTestRediscoveryFinishedEmitter = new EventEmitter<TestNode[]>();
     private readonly onTestDiscoveryStartedEmitter = new EventEmitter<void>();
     private readonly onTestRunStartedEmitter = new EventEmitter<TestNode>();
     private readonly onTestResultEmitter = new EventEmitter<TestResult>();
@@ -13,8 +14,14 @@ export class Commands {
     public get discoveredTest(): Event<TestNode[]> {
         return this.onTestDiscoveryFinishedEmitter.event;
     }
+    public get rediscoveredTest(): Event<TestNode[]> {
+        return this.onTestRediscoveryFinishedEmitter.event;
+    }
     public sendDiscoveredTests(testNodeList: TestNode[]) {
         this.onTestDiscoveryFinishedEmitter.fire(testNodeList);
+    }
+    public sendRediscoveredTests(testNodeList: TestNode[]) {
+        this.onTestRediscoveryFinishedEmitter.fire(testNodeList);
     }
     public get testDiscoveryStarted(): Event<void> {
         return this.onTestDiscoveryStartedEmitter.event;

--- a/src/goTestExplorer.ts
+++ b/src/goTestExplorer.ts
@@ -163,9 +163,9 @@ export class GoTestExplorer {
         if (document.languageId !== 'go') {
             return;
         }
-        let testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
+        const testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
         if (!!testOnSave) {
-            var gotest = this.getGoTestNode(document.uri);
+            const gotest = this.getGoTestNode(document.uri);
             if (gotest instanceof TestNode) {
                 this.runTestSuite(gotest);
             }
@@ -173,13 +173,13 @@ export class GoTestExplorer {
     }
 
     private getGoTestNode(uri: vscode.Uri): TestNode | undefined {
-        let gosuf = '.go';
-        let testsuf = '_test.go';
-        var uristr = uri.fsPath;
+        const gosuf = '.go';
+        const testsuf = '_test.go';
+        const uristr = uri.fsPath;
         if (uristr.endsWith(testsuf)) {
             return this.goTestProvider.getDiscoveredTestNode(uristr);
         } else if (uristr.endsWith(gosuf)) {
-            var testfile = uristr.slice(0, -gosuf.length).concat(testsuf);
+            const testfile = uristr.slice(0, -gosuf.length).concat(testsuf);
             return this.goTestProvider.getDiscoveredTestNode(testfile);
         }
         return undefined;

--- a/src/goTestExplorer.ts
+++ b/src/goTestExplorer.ts
@@ -37,6 +37,16 @@ export class GoTestExplorer {
         context.subscriptions.push(this.commands.testCompleted(this.onTestCompleted, this));
         testDiscoverer.discoverAllTests();
 
+    vscode.workspace.onDidSaveTextDocument(document => {
+        if (document.languageId !== 'go') {
+            return;
+        }
+        let testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
+        if (!!testOnSave) {
+            vscode.commands.executeCommand('goTestExplorer.runAllTest');
+        }
+    }, context.subscriptions);
+
     }
     async onRunSingleTest(testNode: TestNode) {
         this.commands.sendTestRunStarted(testNode);

--- a/src/goTestExplorer.ts
+++ b/src/goTestExplorer.ts
@@ -165,23 +165,24 @@ export class GoTestExplorer {
         }
         let testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
         if (!!testOnSave) {
-            this.goTestProvider.discoveredTests.
-                filter(t => t.isTestSuite).
-                filter(u => this.isSameGoTest(document.uri, u.uri)).
-                forEach(v => this.runTestSuite(v));
+            var gotest = this.getGoTestNode(document.uri);
+            if (gotest instanceof TestNode) {
+                this.runTestSuite(gotest);
+            }
         }
     }
 
-    private isSameGoTest(gofile: vscode.Uri, testfile: vscode.Uri): boolean {
-        let gf = gofile.toString();
-        let tf = testfile.toString();
-        if (gf === tf) {
-            return true;
-        }
+    private getGoTestNode(uri: vscode.Uri): TestNode | undefined {
         let gosuf = '.go';
         let testsuf = '_test.go';
-        return (gf.endsWith(gosuf) && tf.endsWith(testsuf)) &&
-            gf.slice(0, -gosuf.length) === tf.slice(0, -testsuf.length);
+        var uristr = uri.fsPath;
+        if (uristr.endsWith(testsuf)) {
+            return this.goTestProvider.getDiscoveredTestNode(uristr);
+        } else if (uristr.endsWith(gosuf)) {
+            var testfile = uristr.slice(0, -gosuf.length).concat(testsuf);
+            return this.goTestProvider.getDiscoveredTestNode(testfile);
+        }
+        return undefined;
     }
 
 }

--- a/src/goTestExplorer.ts
+++ b/src/goTestExplorer.ts
@@ -165,10 +165,13 @@ export class GoTestExplorer {
         }
         const testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
         if (!!testOnSave) {
-            const gotest = this.getGoTestNode(document.uri);
-            if (gotest instanceof TestNode) {
-                this.runTestSuite(gotest);
-            }
+            const testDiscoverer = new TestDiscovery(this.commands);
+            testDiscoverer.rediscoverTests(document.uri).then(() => {
+                const gotest = this.getGoTestNode(document.uri);
+                if (gotest instanceof TestNode) {
+                    this.runTestSuite(gotest);
+                }
+            });
         }
     }
 

--- a/src/goTestExplorer.ts
+++ b/src/goTestExplorer.ts
@@ -37,15 +37,15 @@ export class GoTestExplorer {
         context.subscriptions.push(this.commands.testCompleted(this.onTestCompleted, this));
         testDiscoverer.discoverAllTests();
 
-    vscode.workspace.onDidSaveTextDocument(document => {
-        if (document.languageId !== 'go') {
-            return;
-        }
-        let testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
-        if (!!testOnSave) {
-            vscode.commands.executeCommand('goTestExplorer.runAllTest');
-        }
-    }, context.subscriptions);
+        vscode.workspace.onDidSaveTextDocument(document => {
+            if (document.languageId !== 'go') {
+                return;
+            }
+            let testOnSave = vscode.workspace.getConfiguration('go')['testOnSave'];
+            if (!!testOnSave) {
+                vscode.commands.executeCommand('goTestExplorer.runAllTest');
+            }
+        }, context.subscriptions);
 
     }
     async onRunSingleTest(testNode: TestNode) {

--- a/src/testDiscovery.ts
+++ b/src/testDiscovery.ts
@@ -28,7 +28,24 @@ export class TestDiscovery {
 
     async discoverTests(uri: vscode.Uri) {
         const items = await TestDiscovery.getGoTestFiles(uri);
-        let promises = items.map(async item => {
+        let promises = TestDiscovery.parseTests(items);
+
+        Promise.all(promises).then(testNodeList => {
+            this.commands.sendDiscoveredTests([].concat(...testNodeList));
+        });
+    }
+
+    async rediscoverTests(uri: vscode.Uri) {
+        const items = await TestDiscovery.getGoTestFiles(uri);
+        let promises = TestDiscovery.parseTests(items);
+
+        Promise.all(promises).then(testNodeList => {
+            this.commands.sendRediscoveredTests([].concat(...testNodeList));
+        });
+    }
+
+    static parseTests(items: Entry[]): Promise<TestNode>[] {
+        return items.map(async item => {
             let suite = new TestNode(item.name, item.uri);
             let symbols = await getTestFunctions(suite.uri, null);
 
@@ -36,44 +53,70 @@ export class TestDiscovery {
             let nodeList = symbols.map(symbol => new TestNode(`${symbol.name}`, suite.uri));
             return new TestNode(suite.name, suite.uri, nodeList);
         });
+    }
 
-        Promise.all(promises).then(testNodeList => {
-            this.commands.sendDiscoveredTests([].concat(...testNodeList)); 
-        });
+    private static async getAllSubfiles(uri: vscode.Uri): Promise<Entry[]> {
+        const fileSystemProvider = new FileSystemProvider();
+
+        let subfiles: Entry[] = [];
+        const stat = await fileSystemProvider.stat(uri);
+        if (stat.type === vscode.FileType.Directory) {
+            const dir = await fileSystemProvider.readDirectory(uri);
+            const entries: Entry[] = dir.map(([name, type]) => ({
+                name: name,
+                uri: vscode.Uri.file(path.join(uri.fsPath, name)),
+                type: type,
+            }));
+            const promises = entries.map(async e => {
+                if (e.type === vscode.FileType.File) {
+                    return [e];
+                } else if (e.type === vscode.FileType.Directory) {
+                    const subentries = await this.getAllSubfiles(e.uri);
+                    return subentries;
+                }
+            });
+            const children = await Promise.all(promises);
+            children.forEach(entries => subfiles.push(...entries))
+        } else if (stat.type === vscode.FileType.File) {
+            const name = path.basename(uri.fsPath);
+            subfiles.push({ name: name, uri: uri, type: stat.type });
+        }
+        return subfiles;
     }
 
     static async getGoTestFiles(uri: vscode.Uri): Promise<Entry[]> {
-        const fileSystemProvider = new FileSystemProvider();
-
-        const children = await fileSystemProvider.readDirectory(uri);
-        const results = this.filterGoTestFileOrDirectory(children);
-        let files = results.filter(([name, type]) => type === vscode.FileType.File)
-            .map(([name, type]) => ({ name: name, uri: vscode.Uri.file(path.join(uri.fsPath, name)), type }));
+        const subfiles: Entry[] = await this.getAllSubfiles(uri);
+        const results: Entry[] = this.filterGoTestFile(subfiles);
+        let files: Entry[] = results.filter(e => e.type === vscode.FileType.File);
 
         let resultfiles = TestDiscovery.filterOutSkipFolders(results);
         if (resultfiles.length === 0) {
             return Promise.resolve(files);
         }
-        var promises = resultfiles.map(([name, type]) =>
-            this.getGoTestFiles(vscode.Uri.file(path.join(uri.fsPath, name))));
-            
+
+        var promises = resultfiles.map(e =>
+            this.getGoTestFiles(vscode.Uri.file(path.join(uri.fsPath, e.name))));
+
         return Promise.all(promises).then(results => {
             let output = results.map(r => [].concat(...r));
             return Promise.resolve(files.concat(...output));
         });
     }
 
-    private static filterOutSkipFolders(results: [string, vscode.FileType][]) {
-        return results.filter(([name, type]) => {
-            const basename = path.basename(name);
-            return type === vscode.FileType.Directory && Config.SkipFolders.indexOf(basename) === -1;
+    private static filterOutSkipFolders(results: Entry[]) {
+        return results.filter(e => {
+            const basename = path.basename(e.name);
+            return e.type === vscode.FileType.Directory && Config.SkipFolders.indexOf(basename) === -1;
         });
     }
 
-    static filterGoTestFileOrDirectory(items: [string, vscode.FileType][]): [string, vscode.FileType][] {
-        return items.filter(([name, type]) => name.endsWith("_test.go")
+    static filterGoTestFile(items: Entry[]): Entry[] {
+        return items.filter(e => this.validGoTestFile(e.name, e.type));
+    }
+
+    static validGoTestFile(name: string, type: vscode.FileType): boolean {
+        return name.endsWith('_test.go')
             && type === vscode.FileType.File
-            || type === vscode.FileType.Directory
-        );
+            || type === vscode.FileType.Directory;
     }
 }


### PR DESCRIPTION
This fixes #8 

Any improvements welcome.

It seems to me that it's running tests in addition to the Go extension's tests, but I guess that's how it's always been. But intensive tests will be twice as long, due to the duplicate tests.

Another point of pain is that all tests will be run, but I am not sure how one would go about shrinking that set.